### PR TITLE
Use shared DockerHub credentials

### DIFF
--- a/concourse/ci.yml
+++ b/concourse/ci.yml
@@ -26,8 +26,8 @@ resources:
     icon: docker
     source:
       repository: govuk/github-commit
-      username: ((docker-username))
-      password: ((docker-hub-authtoken))
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
 jobs:
   - name: update-pipeline
@@ -51,8 +51,8 @@ jobs:
           source:
             repository: ruby
             tag: 2.7.2
-            username: ((docker-username))
-            password: ((docker-hub-authtoken))
+            username: ((docker_hub_username))
+            password: ((docker_hub_authtoken))
         outputs:
         - name: dist
         run:


### PR DESCRIPTION
The pipeline will use the same credentials for DockerHub that other pipelines use (these variables aren't scoped to a pipeline).

I have removed the DockerHub variables added to this pipeline.