### PR TITLE
Use BUILD_JOB_NAME as default GitHub status context

### DIFF
--- a/bin/out
+++ b/bin/out
@@ -53,7 +53,7 @@ end
 
 updater.update_status(
   status: state,
-  context: input.dig(:params, :context) || "Concourse",
+  context: input.dig(:params, :context) || ENV["BUILD_JOB_NAME"] || "Concourse",
   target_url: parse_target_url(input.dig(:params, :target_url)),
   description: input.dig(:params, :description),
 )


### PR DESCRIPTION
This will use a Concourse job's name as the default context for a status.

The benefit is that there will be less duplication of a job name in the job configuration:

Before:

```yaml
  - name: run-tests-in-concourse
    plan:
    - get: commit
      trigger: true
    - put: commit
      params: {status: pending, context: run-tests-in-concourse}
    - task: run-tests
      file: commit/concourse/tasks/run-tests.yml
      on_success:
        put: commit
        params: {status: success, context: run-tests-in-concourse}
      on_failure:
        put: commit
        params: {status: failure, context: run-tests-in-concourse}
      on_abort:
        put: commit
        params: {status: error, context: run-tests-in-concourse}
      on_error:
        put: commit
        params: {status: error, context: run-tests-in-concourse}
```

After:

```yaml
  - name: run-tests-in-concourse
    plan:
    - get: commit
      trigger: true
    - put: commit
      params: {status: pending}
    - task: run-tests
      file: commit/concourse/tasks/run-tests.yml
      on_success:
        put: commit
        params: {status: success}
      on_failure:
        put: commit
        params: {status: failure}
      on_abort: &status-error
        put: commit
        params: {status: error}
      on_error: *status-error
```